### PR TITLE
Fix: match output message type with declared metadata

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -7,7 +7,7 @@ extern "C" fn handle() {
     let new_msg: String = msg::load().expect("Unable to create string");
 
     if new_msg == "PING" {
-        msg::reply_bytes("PONG", 0).expect("Unable to reply");
+        msg::reply("PONG", 0).expect("Unable to reply");
     }
 
     unsafe {
@@ -51,7 +51,7 @@ mod tests {
         assert!(res.log().is_empty());
 
         let res = program.send_bytes(42, String::from("PING").encode());
-        let log = Log::builder().source(1).dest(42).payload_bytes("PONG");
+        let log = Log::builder().source(1).dest(42).payload("PONG");
         assert!(res.contains(&log));
     }
 }


### PR DESCRIPTION
According to the declared [program metadata](https://github.com/gear-dapps/ping/blob/dda14fbededde2b306fb3d56b79de8a4eb7489e9/io/src/lib.rs#L10), handle function should return a `String`

```
impl Metadata for DemoPingMetadata {
    type Init = ();
    type Handle = InOut<String, String>;
...
```

Current behaviour:
- input: `0x1050494e47` (scale encoded "PING" = "\u0010PING")
- output: `0x504f4e47`, not a valid scale encoded string

Expected behaviour:
- input: `0x1050494e47` (scale encoded "PING" = "\u0010PING")
- output: `0x10504f4e47` (scale encoded "PONG" = "\u0010PONG")